### PR TITLE
Fix the option helper to properly fallback to default value

### DIFF
--- a/database/factories/OptionFactory.php
+++ b/database/factories/OptionFactory.php
@@ -1,0 +1,7 @@
+<?php
+
+use Gzero\Core\Models\Option;
+
+$factory->define(Option::class, function () {
+   return [];
+});

--- a/src/Gzero/Core/helpers.php
+++ b/src/Gzero/Core/helpers.php
@@ -238,11 +238,12 @@ if (!function_exists('option')) {
         $option   = app('options')->getOption($categoryKey, $optionKey);
         $language = $language ? $language : app()->getLocale();
 
-        if (array_key_exists($language, $option)) {
-            return $option[$language];
-        } else {
-            return $fallback ? $fallback : false;
+        if ($option == null) {
+            return $fallback;
         }
+
+        $value = array_get($option, $language, $fallback);
+        return $value ? $value : $fallback;
     }
 }
 

--- a/tests/_support/FunctionalTester.php
+++ b/tests/_support/FunctionalTester.php
@@ -1,6 +1,7 @@
 <?php namespace Core;
 
 use Core\_generated\FunctionalTesterActions;
+use Gzero\Core\Models\Option;
 use Gzero\Core\Models\User;
 
 /**
@@ -84,5 +85,10 @@ class FunctionalTester extends \Codeception\Actor {
         $height = config('gzero.image.thumb.height');
 
         return '/images\/' . $fileName . '-' . $width . 'x' . $height . '\.' . $extension . '\?token=.+$/';
+    }
+
+    public function haveOption($attributes = [])
+    {
+        return factory(Option::class)->create($attributes);
     }
 }

--- a/tests/functional/HelpersCest.php
+++ b/tests/functional/HelpersCest.php
@@ -3,6 +3,7 @@
 use Carbon\Carbon;
 use Gzero\Core\Models\Language;
 use Gzero\Core\Services\LanguageService;
+use Gzero\Core\Services\OptionService;
 use Gzero\Core\Services\RoutesService;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\RouteCollection;
@@ -273,5 +274,20 @@ class HelpersCest {
 
         $I->assertEquals($dateTime, $dateTimeInRequestTimezone);
         $I->assertEquals('Australia/Adelaide', $dateTimeInRequestTimezone->getTimezone()->getName());
+    }
+
+    public function optionFallbackToDefaultInAllNullCases(FunctionalTester $I)
+    {
+        $option = $I->haveOption([
+            'category_key' => 'general',
+            'key' => 'someoption',
+            'value' => ["en" => "english value", "pl" => null]
+        ]);
+
+        $I->assertEquals("english value", option('general', 'someoption', 'xxx'));
+        $I->assertEquals("english value", option('general', 'someoption', 'xxx', 'en'));
+
+        $I->assertEquals("xxx", option('general', 'someoption', 'xxx', 'pl'));
+        $I->assertEquals("xxx", option('general', 'someoption', 'xxx', 'fr'));
     }
 }


### PR DESCRIPTION
Example problem situation:
It returned null instead of the default value
when there was null value assigned for a given language