### PR TITLE
Privacy info component fix

### DIFF
--- a/resources/views/layouts/_footer.blade.php
+++ b/resources/views/layouts/_footer.blade.php
@@ -7,7 +7,7 @@
             </div>
         </div>
     </div>
-
-    <privacy-info privacy-policy-url="{{ url(option('general', 'cookies_policy_url', '')) }}"></privacy-info>
+    @php($policyUrl = option('general', 'cookies_policy_url'))
+    <privacy-info privacy-policy-url="{{ ($policyUrl) ? urlMl($policyUrl, app()->getLocale()) : null}}"></privacy-info>
     <div class="loading"><!-- loading container --></div>
 @show


### PR DESCRIPTION
Fixed displaying the link to homepage when the URL is not specified, used `urlMl` in order for the user to not specify language code in the admin panel.